### PR TITLE
CORE-5810 Add /tags/* endpoint error response API docs.

### DIFF
--- a/src/metadata/routes/schemas/tags.clj
+++ b/src/metadata/routes/schemas/tags.clj
@@ -1,6 +1,8 @@
 (ns metadata.routes.schemas.tags
-  (:use [common-swagger-api.schema :only [->optional-param
+  (:use [clojure-commons.error-codes]
+        [common-swagger-api.schema :only [->optional-param
                                           describe
+                                          ErrorResponse
                                           NonBlankString
                                           StandardUserQueryParams]]
         [metadata.routes.schemas.common])
@@ -65,3 +67,7 @@
 
 (s/defschema UpdateAttachedTagsResponse
   {:tags (describe [AttachedTagDetails] "A list of tags and their attached targets")})
+
+(s/defschema ErrorResponseBadTagRequest
+  (assoc ErrorResponse
+    :error_code (describe (s/enum ERR_ILLEGAL_ARGUMENT ERR_NOT_UNIQUE) "Bad Tag Request error codes")))

--- a/src/metadata/routes/tags.clj
+++ b/src/metadata/routes/tags.clj
@@ -23,7 +23,17 @@
       :path-params [data-id :- TargetIdPathParam]
       :query [{:keys [user data-type type]} UpdateAttachedTagsQueryParams]
       :body [body (describe TagIdList "The UUIDs of the tags to attach/detach.")]
-      :return UpdateAttachedTagsResponse
+      :responses {200      {:schema      UpdateAttachedTagsResponse
+                            :description "The tags were attached or detached from the file or folder"}
+                  400      {:schema      ErrorResponseBadTagRequest
+                            :description "The `type` wasn't provided or had a value other than `attach` or `detach`;
+                             or the request body wasn't syntactically correct"}
+                  404      {:schema      ErrorResponseNotFound
+                            :description "One of the provided tag Ids doesn't map to a tag for the authenticated user"}
+                  500      {:schema      ErrorResponseUnchecked
+                            :description "Unchecked errors"}
+                  :default {:schema      ErrorResponse
+                            :description "All other errors"}}
       :summary "Attach/Detach Tags to a File/Folder"
       :description "
 Depending on the `type` parameter, this endpoint either attaches a set of the authenticated user's

--- a/src/metadata/routes/tags.clj
+++ b/src/metadata/routes/tags.clj
@@ -3,7 +3,8 @@
         [metadata.routes.schemas.common]
         [metadata.routes.schemas.tags]
         [ring.util.http-response :only [ok]])
-  (:require [metadata.services.tags :as tags]))
+  (:require [compojure.api.middleware :as middleware]
+            [metadata.services.tags :as tags]))
 
 (defroutes filesystem-tags
   (context "/filesystem/data" []
@@ -69,6 +70,15 @@ authenticated user's tags that contain the fragment."
     (DELETE "/user/:tag-id" []
       :path-params [tag-id :- TagIdPathParam]
       :query [{:keys [user]} StandardUserQueryParams]
+      :coercion middleware/no-response-coercion
+      :responses {200      {:schema      nil
+                            :description "The tag was successfully deleted"}
+                  404      {:schema      ErrorResponseNotFound
+                            :description "`tag-id` wasn't a UUID of a tag owned by the authenticated user"}
+                  500      {:schema      ErrorResponseUnchecked
+                            :description "Unchecked errors"}
+                  :default {:schema      ErrorResponse
+                            :description "All other errors"}}
       :summary "Delete a Tag"
       :description "This endpoint allows a user tag to be deleted, detaching it from all metadata."
       (ok (tags/delete-user-tag user tag-id)))

--- a/src/metadata/routes/tags.clj
+++ b/src/metadata/routes/tags.clj
@@ -35,7 +35,15 @@ tags to the indicated file or folder, or it detaches the set."
 
     (GET "/suggestions" []
       :query [{:keys [user contains limit]} TagSuggestQueryParams]
-      :return TagList
+      :responses {200      {:schema      TagList
+                            :description "zero or more suggestions were returned"}
+                  400      {:schema      ErrorResponseIllegalArgument
+                            :description "the `contains` parameter was missing or
+                                the `limit` parameter was set to a something other than a non-negative number."}
+                  500      {:schema      ErrorResponseUnchecked
+                            :description "Unchecked errors"}
+                  :default {:schema      ErrorResponse
+                            :description "All other errors"}}
       :summary "Suggest a Tag"
       :description "
 Given a textual fragment of a tag's value, this endpoint will list up to a given number of the

--- a/src/metadata/routes/tags.clj
+++ b/src/metadata/routes/tags.clj
@@ -13,7 +13,12 @@
     (GET "/:data-id/tags" []
       :path-params [data-id :- TargetIdPathParam]
       :query [{:keys [user]} StandardUserQueryParams]
-      :return TagList
+      :responses {200      {:schema      TagList
+                            :description "The tags are listed in the response"}
+                  500      {:schema      ErrorResponseUnchecked
+                            :description "Unchecked errors"}
+                  :default {:schema      ErrorResponse
+                            :description "All other errors"}}
       :summary "List Attached Tags"
       :description
       "This endpoint lists the tags of the user that are attached to the indicated file or folder."

--- a/src/metadata/routes/tags.clj
+++ b/src/metadata/routes/tags.clj
@@ -77,7 +77,15 @@ authenticated user's tags that contain the fragment."
       :path-params [tag-id :- TagIdPathParam]
       :query [{:keys [user]} StandardUserQueryParams]
       :body [body (describe TagUpdateRequest "The tag fields to update.")]
-      :return TagDetails
+      :responses {200      {:schema      TagDetails
+                            :description "The tag was successfully created"}
+                  400      {:schema      ErrorResponseBadTagRequest
+                            :description "The `value` was not unique, too long,
+                             or the request body wasn't syntactically correct"}
+                  500      {:schema      ErrorResponseUnchecked
+                            :description "Unchecked errors"}
+                  :default {:schema      ErrorResponse
+                            :description "All other errors"}}
       :summary "Update Tag Labels/Descriptions"
       :description
       "This endpoint allows a tag's label and description to be modified by the owning user."

--- a/src/metadata/routes/tags.clj
+++ b/src/metadata/routes/tags.clj
@@ -53,7 +53,15 @@ authenticated user's tags that contain the fragment."
     (POST "/user" []
       :query [{:keys [user]} StandardUserQueryParams]
       :body [body (describe TagRequest "The user tag to create.")]
-      :return TagDetails
+      :responses {200      {:schema      TagDetails
+                            :description "The tag was successfully created"}
+                  400      {:schema      ErrorResponseBadTagRequest
+                            :description "The `value` was not unique, too long,
+                             or the request body wasn't syntactically correct"}
+                  500      {:schema      ErrorResponseUnchecked
+                            :description "Unchecked errors"}
+                  :default {:schema      ErrorResponse
+                            :description "All other errors"}}
       :summary "Create a Tag"
       :description "This endpoint creates a tag for use by the authenticated user."
       (ok (tags/create-user-tag user body)))


### PR DESCRIPTION
Adds non-200 response documentation to `/tags/*` endpoints, using the error response schemas added by cyverse-de/common-swagger-api#2.

The documentation is mainly an import of the https://github.com/cyverse/DE/blob/gh-pages-beta/api/endpoints/tags.md documentation.