### PR TITLE
CORE-8998 Update Metadata Template endpoints with attribute settings.

### DIFF
--- a/src/metadata/routes/schemas/template.clj
+++ b/src/metadata/routes/schemas/template.clj
@@ -41,6 +41,9 @@
    :is_default (describe Boolean "True if this value is the default for its enumeration type")
    :value      (describe String "The name of the enumeration value")})
 
+(s/defschema TemplateAttrSettings
+  {(describe s/Keyword "Settings key") (describe s/Any "Settings value")})
+
 (s/defschema MetadataTemplateAttr
   {:id
    (describe UUID "The attribute ID")
@@ -73,7 +76,10 @@
    ValidValueTypeEnum
 
    (s/optional-key :values)
-   (describe [TemplateAttrEnumValue] "The list of possible values for enumeration types")})
+   (describe [TemplateAttrEnumValue] "The list of possible values for enumeration types")
+
+   (s/optional-key :settings)
+   (describe TemplateAttrSettings "Arbitrary settings saved by an admin and used by the UI (e.g. OLS query parameters)")})
 
 (s/defschema MetadataTemplate
   (assoc MetadataTemplateListEntry
@@ -107,7 +113,10 @@
    ValidValueTypeEnum
 
    (s/optional-key :values)
-   (describe [TemplateAttrEnumValueUpdate] "The list of possible values for enumeration types")})
+   (describe [TemplateAttrEnumValueUpdate] "The list of possible values for enumeration types")
+
+   (s/optional-key :settings)
+   (describe TemplateAttrSettings "Arbitrary settings saved by an admin and used by the UI (e.g. OLS query parameters)")})
 
 (s/defschema MetadataTemplateUpdate
   {:attributes


### PR DESCRIPTION
The following Metadata Template endpoints will now save arbitrary JSON `settings` for attributes in requests, and will return saved attribute `settings` in results:

* `GET /templates/attr/{attr-id}`
* `GET /templates/{template-id}`
* `POST /admin/templates`
* `PUT /admin/templates/{template-id}`