### PR TITLE
Add `POST /avus/deleter` endpoint.

### DIFF
--- a/src/metadata/persistence/avu.clj
+++ b/src/metadata/persistence/avu.clj
@@ -124,6 +124,16 @@
         (add-orphaned-ids-where-clause avu-ids-to-keep)
         delete)))
 
+(defn delete-target-avu
+  "Deletes the AVU with the given attribute, value, and unit from the given target."
+  [target-types target-id attribute value unit]
+  (delete :avus
+          (where {:target_id   target-id
+                  :target_type [in (map db/->enum-val target-types)]
+                  :attribute   attribute
+                  :value       value
+                  :unit        unit})))
+
 (defn format-avu
   "Formats a Metadata AVU for JSON responses."
   [{:keys [id attribute] :as avu}]

--- a/src/metadata/routes/avus.clj
+++ b/src/metadata/routes/avus.clj
@@ -16,6 +16,13 @@
            :description "Lists AVUs matching parameters in the query string."
            (ok (avus/list-avus params)))
 
+    (POST "/deleter" []
+          :query [{:keys [user]} StandardUserQueryParams]
+          :body [{:keys [target-types target-ids avus]} DeleteTargetAvusRequest]
+          :summary "Delete Target AVUs"
+          :description "Deletes AVUs matching those in the given `avus` list from the given `target-ids`."
+          (ok (avus/delete-target-avus target-types target-ids avus)))
+
     (POST "/filter-targets" []
            :query [{:keys [user]} StandardUserQueryParams]
            :body [{:keys [target-types target-ids avus]} FilterByAvusRequest]

--- a/src/metadata/routes/schemas/avus.clj
+++ b/src/metadata/routes/schemas/avus.clj
@@ -49,3 +49,8 @@
 (s/defschema FilterByAvusRequest
   (merge TargetFilterRequest
          {:avus (describe [AvuFilterRequest] "The AVUs to use to filter the given targets")}))
+
+(s/defschema DeleteTargetAvusRequest
+  (merge TargetIDList
+         TargetTypesList
+         {:avus (describe [(select-keys Avu [:attr :value :unit])] "The AVUs to match for removal")}))

--- a/src/metadata/routes/schemas/common.clj
+++ b/src/metadata/routes/schemas/common.clj
@@ -27,15 +27,19 @@
 (s/defschema TargetIDList
   {:target-ids (describe [UUID] "A list of target IDs")})
 
+(s/defschema TargetTypesList
+  {:target-types (describe [TargetTypeEnum]
+                           (str "The types of the given IDs."
+                                " This list will usually only contain 1 type,"
+                                " but multiple are supported for cases such as `file` and `folder` types"
+                                " where it is known that the `target-ids` will be unique within those types"))})
+
 (s/defschema DataIdList
   {:filesystem (describe [UUID] "A list of UUIDs, each for a file or folder")})
 
 (s/defschema TargetFilterRequest
-  {:target-ids
-   (describe [UUID] "List of IDs to filter")
-
-   :target-types
-   (describe [TargetTypeEnum] "The types of the given IDs")})
+  (merge {:target-ids (describe [UUID] "List of IDs to filter")}
+         TargetTypesList))
 
 (s/defschema TargetItem
   {:id   TargetIdParam

--- a/src/metadata/services/avus.clj
+++ b/src/metadata/services/avus.clj
@@ -2,8 +2,7 @@
   (:use [kameleon.uuids :only [uuid]]
         [korma.db :only [transaction]]
         [slingshot.slingshot :only [throw+]])
-  (:require [clojure.tools.logging :as log]
-            [metadata.amqp :as amqp]
+  (:require [metadata.amqp :as amqp]
             [metadata.persistence.avu :as persistence]))
 
 (defn- filter-targets-by-attr-values
@@ -91,3 +90,16 @@
   (let [avus (get-avu-copies target-type target-id)]
     (copy-avus-to-dest-targets user avus dest-items)
     nil))
+
+(defn delete-target-avus
+  "Deletes the given AVUs from the given targets in a transaction."
+  [target-types target-ids avus]
+  (transaction
+    (doseq [target-id target-ids]
+      (doseq [{:keys [attr value unit]} avus]
+        (persistence/delete-target-avu target-types
+                                       target-id
+                                       attr
+                                       value
+                                       unit))))
+  nil)


### PR DESCRIPTION
This PR will add a `POST /avus/deleter` endpoint for use in cyverse-de/apps#127, which accepts requests like the following:
```
{
  "target-ids": [
    "string"
  ],
  "target-types": [
    "app"
  ],
  "avus": [
    {
      "attr": "string",
      "value": "string",
      "unit": "string"
    }
  ]
}
```
This endpoint deletes AVUs matching those in the given `avus` list from the given `target-ids`. The `target-types` will usually only contain 1 type, but multiple are supported for cases such as `file` and `folder` types where it is known that the `target-ids` will be unique within those types.