### PR TITLE
CORE-11 Migrate some schemas into common-swagger-api.schema.ontologies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/clojure-commons "3.0.3"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.3"]
+                 [org.cyverse/common-swagger-api "2.10.7-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/service-logging "2.8.0"]
                  [org.cyverse/event-messages "0.0.1"]

--- a/src/metadata/routes/ontologies.clj
+++ b/src/metadata/routes/ontologies.clj
@@ -1,10 +1,10 @@
 (ns metadata.routes.ontologies
   (:use [common-swagger-api.schema]
-        [common-swagger-api.schema.ontologies]
         [metadata.routes.schemas.common]
         [metadata.routes.schemas.ontologies]
         [ring.util.http-response :only [ok]])
-  (:require [metadata.services.ontology :as service]))
+  (:require [common-swagger-api.schema.ontologies :as schema]
+            [metadata.services.ontology :as service]))
 
 (defroutes ontologies
   (context "/ontologies" []
@@ -18,7 +18,7 @@
           (ok (service/get-ontology-details-listing)))
 
     (GET "/:ontology-version" []
-          :path-params [ontology-version :- OntologyVersionParam]
+          :path-params [ontology-version :- schema/OntologyVersionParam]
           :query [{:keys [user]} StandardUserQueryParams]
           :return OntologyHierarchyList
           :summary "Get Ontology Hierarchies"
@@ -26,7 +26,7 @@
           (ok (service/list-hierarchies ontology-version)))
 
     (POST "/:ontology-version/filter" []
-           :path-params [ontology-version :- OntologyVersionParam]
+           :path-params [ontology-version :- schema/OntologyVersionParam]
            :query [{:keys [user]} StandardUserQueryParams]
            :body [{:keys [type id attrs]} TargetHierarchyFilterRequest]
            :return OntologyHierarchyList
@@ -37,7 +37,7 @@
            (ok (service/filter-target-hierarchies ontology-version attrs type id)))
 
     (POST "/:ontology-version/filter-targets" []
-           :path-params [ontology-version :- OntologyVersionParam]
+           :path-params [ontology-version :- schema/OntologyVersionParam]
            :query [{:keys [user label]} OntologySearchParams]
            :body [{:keys [target-types target-ids attrs]} OntologySearchFilterRequest]
            :return TargetIDList
@@ -48,8 +48,8 @@
            (ok (service/filter-targets-by-ontology-class-search ontology-version attrs label target-types target-ids)))
 
     (POST "/:ontology-version/:root-iri/filter" []
-           :path-params [ontology-version :- OntologyVersionParam
-                         root-iri :- OntologyClassIRIParam]
+           :path-params [ontology-version :- schema/OntologyVersionParam
+                         root-iri :- schema/OntologyClassIRIParam]
            :query [{:keys [attr user]} OntologyHierarchyFilterParams]
            :body [{:keys [target-types target-ids]} TargetFilterRequest]
            :return OntologyHierarchy
@@ -60,8 +60,8 @@
            (ok (service/filter-hierarchy ontology-version root-iri attr target-types target-ids)))
 
     (POST "/:ontology-version/:root-iri/filter-targets" []
-           :path-params [ontology-version :- OntologyVersionParam
-                         root-iri :- OntologyClassIRIParam]
+           :path-params [ontology-version :- schema/OntologyVersionParam
+                         root-iri :- schema/OntologyClassIRIParam]
            :query [{:keys [attr user]} OntologyHierarchyFilterParams]
            :body [{:keys [target-types target-ids]} TargetFilterRequest]
            :return TargetIDList
@@ -72,8 +72,8 @@
            (ok (service/filter-hierarchy-targets ontology-version root-iri attr target-types target-ids)))
 
     (POST "/:ontology-version/:root-iri/filter-unclassified" []
-           :path-params [ontology-version :- OntologyVersionParam
-                         root-iri :- OntologyClassIRIParam]
+           :path-params [ontology-version :- schema/OntologyVersionParam
+                         root-iri :- schema/OntologyClassIRIParam]
            :query [{:keys [attr user]} OntologyHierarchyFilterParams]
            :body [{:keys [target-types target-ids]} TargetFilterRequest]
            :return TargetIDList
@@ -91,21 +91,21 @@
            :query [{:keys [user]} StandardUserQueryParams]
            :multipart-params [ontology-xml :- String]
            :middleware [service/wrap-multipart-xml-parser]
-           :return OntologyDetails
+           :return schema/OntologyDetails
            :summary "Save an Ontology"
            :description "Saves an Ontology XML document in the database."
            (ok (service/save-ontology-xml user ontology-xml)))
 
     (DELETE "/:ontology-version" []
-             :path-params [ontology-version :- OntologyVersionParam]
+             :path-params [ontology-version :- schema/OntologyVersionParam]
              :query [{:keys [user]} StandardUserQueryParams]
              :summary "Delete an Ontology"
              :description "Marks an Ontology as deleted in the database."
              (ok (service/delete-ontology user ontology-version)))
 
     (DELETE "/:ontology-version/:root-iri" []
-             :path-params [ontology-version :- OntologyVersionParam
-                           root-iri :- OntologyClassIRIParam]
+             :path-params [ontology-version :- schema/OntologyVersionParam
+                           root-iri :- schema/OntologyClassIRIParam]
              :query [{:keys [user]} StandardUserQueryParams]
              :return OntologyHierarchyList
              :summary "Delete an Ontology Hierarchy"
@@ -118,8 +118,8 @@
              (ok (service/delete-hierarchy user ontology-version root-iri)))
 
     (PUT "/:ontology-version/:root-iri" []
-          :path-params [ontology-version :- OntologyVersionParam
-                        root-iri :- OntologyClassIRIParam]
+          :path-params [ontology-version :- schema/OntologyVersionParam
+                        root-iri :- schema/OntologyClassIRIParam]
           :query [{:keys [user]} StandardUserQueryParams]
           :return OntologyHierarchy
           :summary "Save an Ontology Hierarchy"

--- a/src/metadata/routes/ontologies.clj
+++ b/src/metadata/routes/ontologies.clj
@@ -20,7 +20,7 @@
     (GET "/:ontology-version" []
           :path-params [ontology-version :- schema/OntologyVersionParam]
           :query [{:keys [user]} StandardUserQueryParams]
-          :return OntologyHierarchyList
+          :return schema/OntologyHierarchyList
           :summary "Get Ontology Hierarchies"
           :description "List Ontology Hierarchies saved for the given `ontology-version`."
           (ok (service/list-hierarchies ontology-version)))
@@ -29,7 +29,7 @@
            :path-params [ontology-version :- schema/OntologyVersionParam]
            :query [{:keys [user]} StandardUserQueryParams]
            :body [{:keys [type id attrs]} TargetHierarchyFilterRequest]
-           :return OntologyHierarchyList
+           :return schema/OntologyHierarchyList
            :summary "Filter Target's Ontology Hierarchies"
            :description
            "Filters Ontology Hierarchies saved for the given `ontology-version`,
@@ -52,7 +52,7 @@
                          root-iri :- schema/OntologyClassIRIParam]
            :query [{:keys [attr user]} OntologyHierarchyFilterParams]
            :body [{:keys [target-types target-ids]} TargetFilterRequest]
-           :return OntologyHierarchy
+           :return schema/OntologyHierarchy
            :summary "Filter an Ontology Hierarchy"
            :description
            "Filters an Ontology Hierarchy, rooted at the given `root-iri`, returning only the
@@ -107,7 +107,7 @@
              :path-params [ontology-version :- schema/OntologyVersionParam
                            root-iri :- schema/OntologyClassIRIParam]
              :query [{:keys [user]} StandardUserQueryParams]
-             :return OntologyHierarchyList
+             :return schema/OntologyHierarchyList
              :summary "Delete an Ontology Hierarchy"
              :description
              "Removes the Ontology Class for the given `root-iri` and `ontology-version`, and all
@@ -121,7 +121,7 @@
           :path-params [ontology-version :- schema/OntologyVersionParam
                         root-iri :- schema/OntologyClassIRIParam]
           :query [{:keys [user]} StandardUserQueryParams]
-          :return OntologyHierarchy
+          :return schema/OntologyHierarchy
           :summary "Save an Ontology Hierarchy"
           :description
           "Save an Ontology Hierarchy, parsed from the Ontology XML stored with the given

--- a/src/metadata/routes/schemas/ontologies.clj
+++ b/src/metadata/routes/schemas/ontologies.clj
@@ -15,27 +15,6 @@
 (s/defschema OntologyDetailsList
   {:ontologies (describe [schema/OntologyDetails] "List of saved Ontologies")})
 
-(s/defschema OntologyClass
-  {:iri
-   (describe String "The unique IRI for this Ontology Class")
-
-   :label
-   (describe (s/maybe String) "The label annotation of this Ontology Class")
-
-   (s/optional-key :description)
-   (describe (s/maybe String) "The description annotation of this Ontology Class")})
-
-(s/defschema OntologyClassHierarchy
-  (merge OntologyClass
-         {(s/optional-key :subclasses)
-          (describe [(s/recursive #'OntologyClassHierarchy)] "Subclasses of this Ontology Class")}))
-
-(s/defschema OntologyHierarchy
-  {:hierarchy (describe (s/maybe OntologyClassHierarchy) "An Ontology Class hierarchy")})
-
-(s/defschema OntologyHierarchyList
-  {:hierarchies (describe [OntologyClassHierarchy] "A list of Ontology Class hierarchies")})
-
 (s/defschema TargetHierarchyFilterRequest
   (merge TargetItem
          {:attrs

--- a/src/metadata/routes/schemas/ontologies.clj
+++ b/src/metadata/routes/schemas/ontologies.clj
@@ -1,19 +1,19 @@
 (ns metadata.routes.schemas.ontologies
   (:use [common-swagger-api.schema]
-        [common-swagger-api.schema.ontologies]
         [metadata.routes.schemas.common])
-  (:require [schema.core :as s]))
+  (:require [common-swagger-api.schema.ontologies :as schema]
+            [schema.core :as s]))
 
 (s/defschema OntologyHierarchyFilterParams
   (merge StandardUserQueryParams
-         {:attr (describe String "The metadata attribute that stores class IRIs under the given root IRI")}))
+         schema/OntologyHierarchyFilterParams))
 
 (s/defschema OntologySearchParams
   (merge StandardUserQueryParams
          {:label (describe String "The ontology class label search term")}))
 
 (s/defschema OntologyDetailsList
-  {:ontologies (describe [OntologyDetails] "List of saved Ontologies")})
+  {:ontologies (describe [schema/OntologyDetails] "List of saved Ontologies")})
 
 (s/defschema OntologyClass
   {:iri


### PR DESCRIPTION
This PR will replace some schemas in `metadata.routes.schemas.ontologies` with those migrated into `common-swagger-api.schema.ontologies` by cyverse-de/common-swagger-api#19.