### PR TITLE
CORE-11 Migrate some AVU schemas to common-swagger-api.schema.metadata

### DIFF
--- a/src/metadata/routes/avus.clj
+++ b/src/metadata/routes/avus.clj
@@ -1,9 +1,14 @@
 (ns metadata.routes.avus
   (:use [common-swagger-api.schema]
-        [metadata.routes.schemas.common]
+        [metadata.routes.schemas.common
+         :only [AvuSearchQueryParams
+                TargetIDList
+                TargetTypeEnum
+                TargetItemList]]
         [metadata.routes.schemas.avus]
         [ring.util.http-response :only [ok]])
-  (:require [metadata.services.avus :as avus]))
+  (:require [common-swagger-api.schema.metadata :as schema]
+            [metadata.services.avus :as avus]))
 
 (defroutes avus
   (context "/avus" []
@@ -11,7 +16,7 @@
 
     (GET "/" []
            :query [params AvuSearchQueryParams]
-           :return AvuList
+           :return schema/AvuList
            :summary "List AVUs."
            :description "Lists AVUs matching parameters in the query string."
            (ok (avus/list-avus params)))
@@ -34,20 +39,20 @@
            (ok (avus/filter-targets-by-avus target-types target-ids avus)))
 
     (GET "/:target-type/:target-id" []
-          :path-params [target-id :- TargetIdPathParam
+          :path-params [target-id :- schema/TargetIdParam
                         target-type :- TargetTypeEnum]
           :query [{:keys [user]} StandardUserQueryParams]
-          :return AvuList
+          :return schema/AvuList
           :summary "View all Metadata AVUs on a Target"
           :description "Lists all AVUs associated with the target item."
           (ok (avus/list-avus target-type target-id)))
 
     (POST "/:target-type/:target-id" []
-           :path-params [target-id :- TargetIdPathParam
+           :path-params [target-id :- schema/TargetIdParam
                          target-type :- TargetTypeEnum]
            :query [{:keys [user]} StandardUserQueryParams]
-           :body [body (describe AvuListRequest "The Metadata AVU update request")]
-           :return AvuList
+           :body [body schema/AvuListRequest]
+           :return schema/AvuList
            :summary "Add/Update Metadata AVUs"
            :description "
 Adds or updates Metadata AVUs on the given target item.
@@ -59,11 +64,11 @@ matching `attr`, `value`, `unit`, `target`, and `type`."
            (ok (avus/update-avus user target-type target-id body)))
 
     (PUT "/:target-type/:target-id" []
-          :path-params [target-id :- TargetIdPathParam
+          :path-params [target-id :- schema/TargetIdParam
                         target-type :- TargetTypeEnum]
           :query [{:keys [user]} StandardUserQueryParams]
-          :body [body (describe SetAvuRequest "The Metadata AVU save request")]
-          :return AvuList
+          :body [body schema/SetAvuRequest]
+          :return schema/AvuList
           :summary "Set Metadata AVUs on a Target"
           :description "
 Sets Metadata AVUs on the given target item.
@@ -78,7 +83,7 @@ then all remaining AVUs in the request will be added to the target item."
           (ok (avus/set-avus user target-type target-id body)))
 
     (POST "/:target-type/:target-id/copy" []
-           :path-params [target-id :- TargetIdPathParam
+           :path-params [target-id :- schema/TargetIdParam
                     target-type :- TargetTypeEnum]
            :query [{:keys [user]} StandardUserQueryParams]
            :body [body (describe TargetItemList "The destination targets.")]

--- a/src/metadata/routes/comments.clj
+++ b/src/metadata/routes/comments.clj
@@ -4,6 +4,7 @@
         [metadata.routes.schemas.common]
         [ring.util.http-response :only [ok]])
   (:require [compojure.api.middleware :as middleware]
+            [common-swagger-api.schema.metadata :as schema]
             [metadata.services.comments :as comments]))
 
 (defroutes admin-comment-routes
@@ -43,14 +44,14 @@
     :tags ["data-comments"]
 
     (GET "/:data-id/comments" []
-      :path-params [data-id :- TargetIdPathParam]
+      :path-params [data-id :- schema/TargetIdParam]
       :return CommentList
       :summary "Listing Data Comments"
       :description "This endpoint retrieves all of the comments made on a file or folder."
       (ok (comments/list-data-comments data-id)))
 
     (POST "/:data-id/comments" []
-      :path-params [data-id :- TargetIdPathParam]
+      :path-params [data-id :- schema/TargetIdParam]
       :query [{:keys [user data-type]} StandardDataItemQueryParams]
       :body [body (describe CommentRequest "The comment to add.")]
       :return CommentResponse
@@ -59,7 +60,7 @@
       (ok (comments/add-data-comment user data-id data-type body)))
 
     (PATCH "/:data-id/comments/:comment-id" []
-      :path-params [data-id :- TargetIdPathParam
+      :path-params [data-id :- schema/TargetIdParam
                     comment-id :- CommentIdPathParam]
       :query [{:keys [user retracted]} RetractCommentQueryParams]
       :summary "Retract/Readmit a Comment"
@@ -74,7 +75,7 @@ This endpoint also allows a user to readmit a comment the user previously retrac
     :tags ["admin-data-comments"]
 
     (DELETE "/:data-id/comments/:comment-id" []
-      :path-params [data-id :- TargetIdPathParam
+      :path-params [data-id :- schema/TargetIdParam
                     comment-id :- CommentIdPathParam]
       :query [{:keys [user]} StandardUserQueryParams]
       :summary "Delete a Comment"
@@ -83,7 +84,7 @@ This endpoint also allows a user to readmit a comment the user previously retrac
       (ok (comments/delete-data-comment data-id comment-id)))
 
     (PATCH "/:data-id/comments/:comment-id" []
-      :path-params [data-id :- TargetIdPathParam
+      :path-params [data-id :- schema/TargetIdParam
                     comment-id :- CommentIdPathParam]
       :query [{:keys [user retracted]} RetractCommentQueryParams]
       :summary "Retract/Readmit a Comment"
@@ -98,14 +99,14 @@ This endpoint also allows a user to readmit a comment the user previously retrac
     :tags ["app-comments"]
 
     (GET "/:app-id/comments" []
-      :path-params [app-id :- TargetIdPathParam]
+      :path-params [app-id :- schema/TargetIdParam]
       :return CommentList
       :summary "Listing App Comments"
       :description "This endpoint retrieves all of the comments made on an app."
       (ok (comments/list-app-comments app-id)))
 
     (POST "/:app-id/comments" []
-      :path-params [app-id :- TargetIdPathParam]
+      :path-params [app-id :- schema/TargetIdParam]
       :query [{:keys [user]} StandardUserQueryParams]
       :body [body (describe CommentRequest "The comment to add.")]
       :return CommentResponse
@@ -114,7 +115,7 @@ This endpoint also allows a user to readmit a comment the user previously retrac
       (ok (comments/add-app-comment user app-id body)))
 
     (PATCH "/:app-id/comments/:comment-id" []
-      :path-params [app-id :- TargetIdPathParam
+      :path-params [app-id :- schema/TargetIdParam
                     comment-id :- CommentIdPathParam]
       :query [{:keys [user retracted]} RetractCommentQueryParams]
       :summary "Retract/Readmit a Comment"
@@ -129,7 +130,7 @@ This endpoint also allows a user to readmit a comment the user previously retrac
     :tags ["admin-app-comments"]
 
     (DELETE "/:app-id/comments/:comment-id" []
-      :path-params [app-id :- TargetIdPathParam
+      :path-params [app-id :- schema/TargetIdParam
                     comment-id :- CommentIdPathParam]
       :query [{:keys [user]} StandardUserQueryParams]
       :summary "Delete an App Comment"
@@ -137,7 +138,7 @@ This endpoint also allows a user to readmit a comment the user previously retrac
       (ok (comments/delete-app-comment app-id comment-id)))
 
     (PATCH "/:app-id/comments/:comment-id" []
-      :path-params [app-id :- TargetIdPathParam
+      :path-params [app-id :- schema/TargetIdParam
                     comment-id :- CommentIdPathParam]
       :query [{:keys [user retracted]} RetractCommentQueryParams]
       :summary "Retract/Readmit a Comment"

--- a/src/metadata/routes/favorites.clj
+++ b/src/metadata/routes/favorites.clj
@@ -3,7 +3,8 @@
         [metadata.routes.schemas.common]
         [metadata.routes.schemas.favorites]
         [ring.util.http-response :only [ok]])
-  (:require [metadata.services.favorites :as fave]))
+  (:require [common-swagger-api.schema.metadata :as schema]
+            [metadata.services.favorites :as fave]))
 
 (defroutes favorites
   (context "/favorites" []
@@ -24,14 +25,14 @@
       (ok (fave/list-favorite-data-ids user entity-type)))
 
     (DELETE "/filesystem/:data-id" []
-      :path-params [data-id :- TargetIdPathParam]
+      :path-params [data-id :- schema/TargetIdParam]
       :query [{:keys [user]} StandardUserQueryParams]
       :summary "Unmark a Data Resource as Favorite"
       :description "This endpoint removes a file or folder from the authenticated user's favorites."
       (ok (fave/remove-favorite user data-id)))
 
    (PUT "/filesystem/:data-id" []
-     :path-params [data-id :- TargetIdPathParam]
+     :path-params [data-id :- schema/TargetIdParam]
      :query [{:keys [user data-type]} StandardDataItemQueryParams]
      :summary "Mark a Data Resource as Favorite"
      :description "This endpoint marks a given file or folder a favorite of the authenticated user."

--- a/src/metadata/routes/schemas/avus.clj
+++ b/src/metadata/routes/schemas/avus.clj
@@ -1,50 +1,14 @@
 (ns metadata.routes.schemas.avus
-  (:use [common-swagger-api.schema :only [->optional-param
-                                          describe
-                                          NonBlankString
-                                          StandardUserQueryParams]]
-        [metadata.routes.schemas.common])
-  (:require [schema.core :as s])
-  (:import [java.util UUID]))
-
-(def AvuIdPathParam (describe UUID "The AVU's UUID"))
-(def AvuIdParam AvuIdPathParam)
-
-(s/defschema Avu
-  {:id AvuIdParam
-   :attr (describe String "The Attribute's name")
-   :value (describe String "The Attribute's value")
-   :unit (describe String "The Attribute's unit")
-   :target_id TargetIdPathParam
-   :created_by (describe String "The ID of the user who created the AVU")
-   :modified_by (describe String "The ID of the user who last modified the AVU")
-   :created_on (describe Long "The date the AVU was created in ms since the POSIX epoch")
-   :modified_on (describe Long "The date the AVU was last modified in ms since the POSIX epoch")
-   (s/optional-key :avus) (describe [(s/recursive #'Avu)] "AVUs attached to this AVU")})
-
-(s/defschema AvuList
-  {:avus (describe [Avu] "The list of AVUs")})
-
-(s/defschema AvuRequest
-  (-> Avu
-      (->optional-param :id)
-      (->optional-param :target_id)
-      (->optional-param :created_by)
-      (->optional-param :modified_by)
-      (->optional-param :created_on)
-      (->optional-param :modified_on)
-      (assoc (s/optional-key :avus)
-             (describe [(s/recursive #'AvuRequest)] "AVUs attached to this AVU"))))
-
-(s/defschema AvuListRequest
-  {:avus
-   (describe [AvuRequest] "The AVUs to save for the target data item")})
-
-(s/defschema SetAvuRequest
-  (->optional-param AvuListRequest :avus))
+  (:use [common-swagger-api.schema :only [describe]]
+        [metadata.routes.schemas.common
+         :only [TargetFilterRequest
+                TargetIDList
+                TargetTypesList]])
+  (:require [common-swagger-api.schema.metadata :as schema]
+            [schema.core :as s]))
 
 (s/defschema AvuFilterRequest
-  (select-keys Avu [:attr :value]))
+  (select-keys schema/Avu [:attr :value]))
 
 (s/defschema FilterByAvusRequest
   (merge TargetFilterRequest
@@ -53,4 +17,4 @@
 (s/defschema DeleteTargetAvusRequest
   (merge TargetIDList
          TargetTypesList
-         {:avus (describe [(select-keys Avu [:attr :value :unit])] "The AVUs to match for removal")}))
+         {:avus (describe [(select-keys schema/Avu [:attr :value :unit])] "The AVUs to match for removal")}))

--- a/src/metadata/routes/schemas/common.clj
+++ b/src/metadata/routes/schemas/common.clj
@@ -1,13 +1,12 @@
 (ns metadata.routes.schemas.common
   (:use [common-swagger-api.schema :only [describe StandardUserQueryParams]])
-  (:require [schema.core :as s])
+  (:require [common-swagger-api.schema.metadata :as schema]
+            [schema.core :as s])
   (:import [java.util UUID]))
 
 (def DataTypes ["file" "folder"])
 (def TargetTypes (concat DataTypes ["analysis" "app" "user"]))
 
-(def TargetIdPathParam (describe UUID "The target item's UUID"))
-(def TargetIdParam TargetIdPathParam)
 (def TargetTypeEnum (apply s/enum TargetTypes))
 
 (def DataTypeEnum (apply s/enum DataTypes))
@@ -42,7 +41,7 @@
          TargetTypesList))
 
 (s/defschema TargetItem
-  {:id   TargetIdParam
+  {:id   schema/TargetIdParam
    :type (describe TargetTypeEnum "The type of this data item")})
 
 (s/defschema TargetItemList

--- a/src/metadata/routes/tags.clj
+++ b/src/metadata/routes/tags.clj
@@ -4,6 +4,7 @@
         [metadata.routes.schemas.tags]
         [ring.util.http-response :only [ok]])
   (:require [compojure.api.middleware :as middleware]
+            [common-swagger-api.schema.metadata :as schema]
             [metadata.services.tags :as tags]))
 
 (defroutes filesystem-tags
@@ -39,7 +40,7 @@
       (ok))
 
     (GET "/:data-id/tags" []
-      :path-params [data-id :- TargetIdPathParam]
+      :path-params [data-id :- schema/TargetIdParam]
       :query [{:keys [user]} StandardUserQueryParams]
       :responses {200      {:schema      TagList
                             :description "The tags are listed in the response"}
@@ -53,7 +54,7 @@
       (ok (tags/list-attached-tags user data-id)))
 
     (PATCH "/:data-id/tags" []
-      :path-params [data-id :- TargetIdPathParam]
+      :path-params [data-id :- schema/TargetIdParam]
       :query [{:keys [user data-type type]} UpdateAttachedTagsQueryParams]
       :body [body (describe TagIdList "The UUIDs of the tags to attach/detach.")]
       :responses {200      {:schema      AttachedTagsListing


### PR DESCRIPTION
This PR will update endpoint docs to use the AVU schemas migrated by cyverse-de/common-swagger-api#21 from `metadata.routes.schemas.avus` and `metadata.routes.schemas.common/TargetIdPathParam` (renamed to `TargetIdParam`).