### PR TITLE
Use http-kit as the webserver, experimentally

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,9 +30,9 @@
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-swagger-api "2.10.7-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.3"]
-                 [org.cyverse/service-logging "2.8.0"]
+                 [org.cyverse/service-logging "2.8.2"]
                  [org.cyverse/event-messages "0.0.1"]
-                 [ring/ring-jetty-adapter "1.6.0"]
+                 [http-kit "2.3.0"]
                  [sanitize-filename "0.1.0"]
                  [slingshot "0.12.2"]]
   :main ^:skip-aot metadata.core

--- a/src/metadata/core.clj
+++ b/src/metadata/core.clj
@@ -35,16 +35,16 @@
    ["-v" "--version" "Print out the version number."]
    ["-h" "--help"]])
 
-(defn run-jetty
+(defn run-server
   [port]
   (require 'metadata.routes
-           'ring.adapter.jetty)
+           'org.httpkit.server)
   (log/warn "Started listening on" (config/listen-port))
-  ((eval 'ring.adapter.jetty/run-jetty) (eval 'metadata.routes/app) {:port (or port (config/listen-port))}))
+  ((eval 'org.httpkit.server/run-server) (eval 'metadata.routes/app) {:port (or port (config/listen-port))}))
 
 (defn -main
   [& args]
   (tc/with-logging-context config/svc-info
     (let [{:keys [options arguments errors summary]} (ccli/handle-args config/svc-info args cli-options)]
       (init-service (:config options))
-      (run-jetty (:port options)))))
+      (run-server (:port options)))))


### PR DESCRIPTION
This is pretty experimental but I wanted to put it up in case others want to play with it. The `service-logging` update purges a key that can't be logged (it's an `AsyncChannel`, not really something you output as JSON). The rest just uses http-kit's server instead of jetty's. I haven't used http-kit's http client at all (though I dunno if I could in this project anyway) since it seems somewhat more intensive to do that.

For reference, http://www.http-kit.org/