### PR TITLE
New target types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ test2junit
 
 GIT_COMMIT
 VERSION
+
+metadata.properties

--- a/src/metadata/routes/schemas/common.clj
+++ b/src/metadata/routes/schemas/common.clj
@@ -5,7 +5,7 @@
             [schema.core :as s])
   (:import [java.util UUID]))
 
-(def TargetTypes (concat DataTypes ["analysis" "app" "user"]))
+(def TargetTypes (concat DataTypes ["analysis" "app" "user" "quick_launch" "instant_launch"]))
 
 (def TargetTypeEnum (apply s/enum TargetTypes))
 
@@ -13,14 +13,14 @@
 
 (s/defschema StandardDataItemQueryParams
   (assoc StandardUserQueryParams
-    :data-type DataTypeParam))
+         :data-type DataTypeParam))
 
 (s/defschema AvuSearchQueryParams
   (assoc StandardUserQueryParams
-    (s/optional-key :attribute)   (describe [String] "Attribute names to search for.")
-    (s/optional-key :target-type) (describe [TargetTypeEnum] "Target types to search for.")
-    (s/optional-key :value)       (describe [String] "Values to search for.")
-    (s/optional-key :unit)        (describe [String] "Units to search for.")))
+         (s/optional-key :attribute)   (describe [String] "Attribute names to search for.")
+         (s/optional-key :target-type) (describe [TargetTypeEnum] "Target types to search for.")
+         (s/optional-key :value)       (describe [String] "Values to search for.")
+         (s/optional-key :unit)        (describe [String] "Units to search for.")))
 
 (s/defschema TargetIDList
   {:target-ids (describe [UUID] "A list of target IDs")})


### PR DESCRIPTION
Adds the instant_launch and quick_launch values to the TargetTypes enum. Also adds metadata.properties to the .gitignore. Looks like my code formatter made some changes as well, but that appears to only be spacing.