### PR TITLE
CORE-11 Migrate permanent-id-request endpoint schemas and docs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.cyverse/clojure-commons "3.0.6"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.7"]
+                 [org.cyverse/common-swagger-api "3.2.1"]
                  [org.cyverse/kameleon "3.0.4"]
                  [org.cyverse/service-logging "2.8.2"]
                  [org.cyverse/event-messages "0.0.1"]

--- a/src/metadata/routes/permanent_id_requests.clj
+++ b/src/metadata/routes/permanent_id_requests.clj
@@ -4,7 +4,8 @@
         [metadata.routes.schemas.permanent-id-requests]
         [metadata.services.permanent-id-requests]
         [otel.middleware :only [otel-middleware]]
-        [ring.util.http-response :only [ok]]))
+        [ring.util.http-response :only [ok]])
+  (:require [common-swagger-api.schema.permanent-id-requests :as schema]))
 
 (defroutes permanent-id-request-routes
   (context "/permanent-id-requests" []
@@ -14,8 +15,8 @@
       :middleware [otel-middleware]
       :query [params PermanentIDRequestListPagingParams]
       :return PermanentIDRequestList
-      :summary "List Permanent ID Requests"
-      :description "Lists all Permanent ID Requests submitted by the requesting user."
+      :summary schema/PermanentIDRequestListSummary
+      :description schema/PermanentIDRequestListDescription
       (ok (list-permanent-id-requests params)))
 
     (POST "/" []
@@ -23,36 +24,33 @@
       :query [{:keys [user]} StandardUserQueryParams]
       :body [body PermanentIDRequest]
       :return PermanentIDRequestDetails
-      :summary "Create a Permanent ID Request"
-      :description "Creates a Permanent ID Request for the requesting user."
+      :summary schema/PermanentIDRequestSummary
+      :description schema/PermanentIDRequestDescription
       (ok (create-permanent-id-request user body)))
 
     (GET "/status-codes" []
       :middleware [otel-middleware]
       :query [params StandardUserQueryParams]
-      :return PermanentIDRequestStatusCodeList
-      :summary "List Permanent ID Request Status Codes"
-      :description
-"Lists all Permanent ID Request Status Codes that have been assigned to a request status update.
- This allows a status to easily be reused by admins in future status updates."
+      :return schema/PermanentIDRequestStatusCodeList
+      :summary schema/PermanentIDRequestStatusCodeListSummary
+      :description schema/PermanentIDRequestStatusCodeListDescription
       (ok (list-permanent-id-request-status-codes params)))
 
     (GET "/types" []
       :middleware [otel-middleware]
       :query [params StandardUserQueryParams]
-      :return PermanentIDRequestTypeList
-      :summary "List Permanent ID Request Types"
-      :description
-      "Lists the allowed Permanent ID Request Types the user can select when submitting a new request."
+      :return schema/PermanentIDRequestTypeList
+      :summary schema/PermanentIDRequestTypesSummary
+      :description schema/PermanentIDRequestTypesDescription
       (ok (list-permanent-id-request-types params)))
 
     (GET "/:request-id" []
       :middleware [otel-middleware]
-      :path-params [request-id :- PermanentIDRequestIdParam]
+      :path-params [request-id :- schema/PermanentIDRequestIdParam]
       :query [{:keys [user]} StandardUserQueryParams]
       :return PermanentIDRequestDetails
-      :summary "List Permanent ID Request Details"
-      :description "Allows a user to retrieve details for one of their Permanent ID Request submissions."
+      :summary schema/PermanentIDRequestDetailsSummary
+      :description schema/PermanentIDRequestDetailsDescription
       (ok (get-permanent-id-request user request-id)))))
 
 (defroutes admin-permanent-id-request-routes
@@ -63,32 +61,25 @@
       :middleware [otel-middleware]
       :query [params PermanentIDRequestListPagingParams]
       :return PermanentIDRequestList
-      :summary "List Permanent ID Requests"
-      :description "Allows administrators to list Permanent ID Requests from all users."
+      :summary schema/PermanentIDRequestAdminListSummary
+      :description schema/PermanentIDRequestAdminListDescription
       (ok (admin-list-permanent-id-requests params)))
 
     (GET "/:request-id" []
       :middleware [otel-middleware]
-      :path-params [request-id :- PermanentIDRequestIdParam]
+      :path-params [request-id :- schema/PermanentIDRequestIdParam]
       :query [{:keys [user]} StandardUserQueryParams]
       :return PermanentIDRequestDetails
-      :summary "Get Permanent ID Request Details"
-      :description "Allows administrators to retrieve details for a Permanent ID Request from any user."
+      :summary schema/PermanentIDRequestAdminDetailsSummary
+      :description schema/PermanentIDRequestAdminDetailsDescription
       (ok (admin-get-permanent-id-request user request-id)))
 
     (POST "/:request-id/status" []
       :middleware [otel-middleware]
-      :path-params [request-id :- PermanentIDRequestIdParam]
+      :path-params [request-id :- schema/PermanentIDRequestIdParam]
       :query [{:keys [user]} StandardUserQueryParams]
-      :body [body PermanentIDRequestStatusUpdate]
+      :body [body schema/PermanentIDRequestStatusUpdate]
       :return PermanentIDRequestDetails
-      :summary "Update the Status of a Permanent ID Request"
-      :description
-"Allows administrators to update the status of a Permanent ID Request from any user.
-
-`Note`: If the `permanent_id` is provided in the request, then the Permanent ID Request must not already
-have a `permanent_id` set, otherwise an error is returned and the Status is not updated.
-
-`Note`: The status code is case-sensitive, and if it isn't defined in the database already then it will
- be added to the list of known status codes."
+      :summary schema/PermanentIDRequestAdminStatusUpdateSummary
+      :description schema/PermanentIDRequestAdminStatusUpdateDescription
       (ok (update-permanent-id-request request-id user body)))))

--- a/src/metadata/routes/schemas/permanent_id_requests.clj
+++ b/src/metadata/routes/schemas/permanent_id_requests.clj
@@ -6,78 +6,33 @@
                                           StandardUserQueryParams]]
         [clojure-commons.error-codes]
         [metadata.routes.schemas.common])
-  (:require [metadata.persistence.permanent-id-requests :as db]
+  (:require [common-swagger-api.schema.permanent-id-requests :as schema]
+            [metadata.persistence.permanent-id-requests :as db]
+            [schema-tools.core :as st]
             [schema.core :as s])
   (:import [java.util UUID]))
 
-(def PermanentIDRequestIdParam (describe UUID "The Permanent ID Requests's UUID"))
 (def PermanentIDRequestTypeEnum (apply s/enum (map :type (db/list-permanent-id-request-types))))
 
 (s/defschema PermanentIDRequest
-  {:type (describe PermanentIDRequestTypeEnum "The type of persistent ID requested")
-   :target_id (describe UUID "The UUID of the data item for which the persistent ID is being requested")
-   :target_type DataTypeParam
-   (s/optional-key :original_path) (describe String "The path associated with the given `target_id`")
-   (s/optional-key :permanent_id) (describe String "The identifier of a completed Permanent ID Request")})
+  (st/merge schema/PermanentID
+            schema/PermanentIDRequestOrigPath
+            {:type        (describe PermanentIDRequestTypeEnum "The type of persistent ID requested")
+             :target_id   (describe UUID "The UUID of the data item for which the persistent ID is being requested")
+             :target_type DataTypeParam}))
 
 (s/defschema PermanentIDRequestBase
-  (merge PermanentIDRequest
-    {:id PermanentIDRequestIdParam
-     :requested_by (describe String "The username of the user that submitted the Permanent ID Request")}))
-
-(s/defschema PermanentIDRequestStatusUpdate
-  {(s/optional-key :status) (describe String "The status code of the Permanent ID Request update")
-   (s/optional-key :comments) (describe String "The curator comments of the Permanent ID Request status update")
-   (s/optional-key :permanent_id) (describe String "The identifier of a completed Permanent ID Request")})
-
-(s/defschema PermanentIDRequestStatus
-  (merge PermanentIDRequestStatusUpdate
-    {:status_date (describe Long "The timestamp of the Permanent ID Request status update")
-     :updated_by (describe String "The username that updated the Permanent ID Request status")}))
+  (st/merge schema/PermanentIDRequestBase PermanentIDRequest))
 
 (s/defschema PermanentIDRequestDetails
-  (merge PermanentIDRequestBase
-    {:history (describe [PermanentIDRequestStatus] "A list of Permanent ID Request status updates")}))
+  (st/merge schema/PermanentIDRequestDetails PermanentIDRequestBase))
 
 (s/defschema PermanentIDRequestListing
-  (merge PermanentIDRequestBase
-    {:date_submitted (describe Long "The timestamp of the Permanent ID Request submission")
-     :status (describe String "The current status of the Permanent ID Request")
-     :date_updated (describe Long "The timestamp of the last Permanent ID Request status update")
-     :updated_by (describe String "The username of the user that last updated the Permanent ID Request status")}))
+  (st/merge schema/PermanentIDRequestListing PermanentIDRequestBase))
 
 (s/defschema PermanentIDRequestList
-  {:requests (describe [PermanentIDRequestListing] "A list of Permanent ID Requests")
-   :total    (describe Long "The total number of permanent id requests in the listing.")})
-
-(def ValidPermanentIDRequestListSortFields
-  (s/enum
-    :type
-    :target_type
-    :requested_by
-    :date_submitted
-    :status
-    :date_updated
-    :updated_by))
+  (st/merge schema/PermanentIDRequestList
+            {:requests (describe [PermanentIDRequestListing] "A list of Permanent ID Requests")}))
 
 (s/defschema PermanentIDRequestListPagingParams
-  (-> PagingParams
-      (assoc SortFieldOptionalKey       (describe ValidPermanentIDRequestListSortFields SortFieldDocs)
-             (s/optional-key :statuses) (describe [String] "Status Codes with which to filter results"))
-      (merge StandardUserQueryParams)))
-
-(s/defschema PermanentIDRequestStatusCode
-  {:id (describe UUID "The Status Code's UUID")
-   :name (describe String "The Status Code")
-   :description (describe String "A brief description of the Status Code")})
-
-(s/defschema PermanentIDRequestStatusCodeList
-  {:status_codes (describe [PermanentIDRequestStatusCode] "A list of Permanent ID Request Status Codes")})
-
-(s/defschema PermanentIDRequestType
-  {:id (describe UUID "The Request Type's UUID")
-   :type (describe String "The Request Type")
-   :description (describe String "A brief description of the Request Type")})
-
-(s/defschema PermanentIDRequestTypeList
-  {:request_types (describe [PermanentIDRequestType] "A list of Permanent ID Request Types")})
+  (st/merge schema/PermanentIDRequestListPagingParams StandardUserQueryParams))


### PR DESCRIPTION
This PR will migrate `metadata.routes.permanent-id-requests` docs and `metadata.routes.schemas.permanent-id-requests` schemas into `common-swagger-api.schema.permanent-id-requests` for use in `terrain`.

There are some differences in which fields are allowed in requests and responses between `metadata` and `terrain` services, so `metadata.routes.schemas.permanent-id-requests` modifies some of the schemas from `common-swagger-api.schema.permanent-id-requests` with fields specific to this service. For example, the `type` enum values loaded from the db, `target_id`, `target_type`, and the `StandardUserQueryParams`.

This PR requires cyverse-de/common-swagger-api#72 to be merged first.