### PR TITLE
CORE-1910 Ensure DOI Request status history in ASC order

### DIFF
--- a/src/metadata/core.clj
+++ b/src/metadata/core.clj
@@ -39,7 +39,7 @@
   [port]
   (require 'metadata.routes
            'ring.adapter.jetty)
-  (log/warn "Started listening on" (config/listen-port))
+  (log/warn "Started listening on" (or port (config/listen-port)))
   ((eval 'ring.adapter.jetty/run-jetty) (eval 'metadata.routes/app) {:port (or port (config/listen-port))}))
 
 (defn -main

--- a/src/metadata/persistence/permanent_id_requests.clj
+++ b/src/metadata/persistence/permanent_id_requests.clj
@@ -74,7 +74,7 @@
   "Gets Permanent ID Request details. If the given user is not nil, only fetches details if the request
   was submitted by the given user."
   [user request-id]
-  ((comp remove-nil-values first)
+  (some->
     (select [:permanent_id_requests :r]
       (fields :r.id
               :types.type
@@ -85,7 +85,9 @@
               :permanent_id)
       (join [:permanent_id_request_types :types] {:types.id :r.type})
       (where-if-defined {:r.id request-id
-                         :requested_by user}))))
+                         :requested_by user}))
+    first
+    remove-nil-values))
 
 (defn get-most-recent-status
   "Gets the most recent status for a Permanent ID Request."

--- a/src/metadata/persistence/permanent_id_requests.clj
+++ b/src/metadata/persistence/permanent_id_requests.clj
@@ -147,6 +147,7 @@
               :updated_by)
       (join [:permanent_id_request_status_codes :status_codes]
             {:status_codes.id :statuses.permanent_id_request_status_code})
+      (order :status_date :ASC)
       (where {:permanent_id_request request-id}))))
 
 (defn- request-type-subselect


### PR DESCRIPTION
This PR will ensure Permanent ID Request status history is listed in ASC order, as expected by the endpoints in terrain.

This PR also includes a couple of other minor bug fixes:
* Return the correct error message (not an unhandled exception) when a request is not found.
* Log the actual port number used at startup.