### PR TITLE
CORE-2034 Accept a list of target-ids in /avus endpoint

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,4 @@
+{:lint-as {korma.core/delete clojure.core/->
+           korma.core/insert clojure.core/->
+           korma.core/select clojure.core/->
+           korma.core/update clojure.core/->}}

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@
 *.iws
 
 ## Plugin-specific files:
-.clj-kondo
+.clj-kondo/.cache
+.clj-kondo/imports
 .eastwood
 .lsp
 

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  [org.cyverse/clojure-commons "3.0.9"]
                  [org.cyverse/common-cfg "2.8.3"]
                  [org.cyverse/common-cli "2.8.2"]
-                 [org.cyverse/common-swagger-api "3.4.5"]
+                 [org.cyverse/common-swagger-api "3.4.10"]
                  [org.cyverse/kameleon "3.0.10"]
                  [org.cyverse/service-logging "2.8.4"]
                  [ring/ring-core "1.12.2"]

--- a/src/metadata/persistence/avu.clj
+++ b/src/metadata/persistence/avu.clj
@@ -148,11 +148,12 @@
 
 (defn- find-avus
   "Searches for AVUs matching the given criteria."
-  [attributes target-types values units]
+  [attributes target-types target-ids values units]
   (let [add-criterion (fn [query f vs] (if (seq vs) (where query {f [in vs]}) query))]
     (-> (select* :avus)
         (add-criterion :attribute attributes)
         (add-criterion :target_type (map db/->enum-val target-types))
+        (add-criterion :target_id target-ids)
         (add-criterion :value values)
         (add-criterion :unit units)
         (select))))
@@ -161,5 +162,5 @@
   "Lists AVUs for the given target."
   ([target-type target-id]
    (map format-avu (get-avus-for-target target-type target-id)))
-  ([attributes target-types values units]
-   (map format-avu (find-avus attributes target-types values units))))
+  ([attributes target-types target-ids values units]
+   (map format-avu (find-avus attributes target-types target-ids values units))))

--- a/src/metadata/persistence/avu.clj
+++ b/src/metadata/persistence/avu.clj
@@ -1,9 +1,20 @@
 (ns metadata.persistence.avu
-  (:use [korma.core :exclude [update]]
-        [korma.db :only [transaction]]
-        [slingshot.slingshot :only [throw+]])
   (:require [kameleon.db :as db]
-            [korma.core :as sql]))
+            [korma.core :as sql :refer [delete
+                                        delete*
+                                        fields
+                                        insert
+                                        modifier
+                                        select
+                                        select*
+                                        set-fields
+                                        sqlfn
+                                        values
+                                        where]]
+            [slingshot.slingshot :refer [throw+]]))
+
+;; Declarations to eliminate lint warnings for korma predicates.
+(declare in not-in now)
 
 (defn- target-where-clause
   "Adds a where-clause to the given query for the given target."

--- a/src/metadata/routes/avus.clj
+++ b/src/metadata/routes/avus.clj
@@ -1,14 +1,23 @@
 (ns metadata.routes.avus
-  (:use [common-swagger-api.schema]
-        [metadata.routes.schemas.common
-         :only [AvuSearchQueryParams
-                TargetIDList
-                TargetTypeEnum
-                TargetItemList]]
-        [metadata.routes.schemas.avus]
-        [ring.util.http-response :only [ok]])
-  (:require [common-swagger-api.schema.metadata :as schema]
-            [metadata.services.avus :as avus]))
+  (:require [common-swagger-api.schema :refer [context
+                                               defroutes
+                                               describe
+                                               GET
+                                               POST
+                                               PUT
+                                               StandardUserQueryParams]]
+            [common-swagger-api.schema.metadata :as schema]
+            [metadata.routes.schemas.avus :refer [DeleteTargetAvusRequest
+                                                  FilterByAvusRequest]]
+            [metadata.routes.schemas.common :refer [AvuSearchQueryParams
+                                                    TargetIDList
+                                                    TargetTypeEnum
+                                                    TargetItemList]]
+            [metadata.services.avus :as avus]
+            [ring.util.http-response :refer [ok]]))
+
+;; Declarations to eliminate lint warnings for path and query parameter bindings.
+(declare params body user avus target-types target-ids target-type target-id)
 
 (defroutes avus
   (context "/avus" []

--- a/src/metadata/routes/avus.clj
+++ b/src/metadata/routes/avus.clj
@@ -9,7 +9,8 @@
             [common-swagger-api.schema.metadata :as schema]
             [metadata.routes.schemas.avus :refer [DeleteTargetAvusRequest
                                                   FilterByAvusRequest]]
-            [metadata.routes.schemas.common :refer [AvuSearchQueryParams
+            [metadata.routes.schemas.common :refer [AvuSearchParams
+                                                    AvuSearchQueryParams
                                                     TargetIDList
                                                     TargetTypeEnum
                                                     TargetItemList]]
@@ -46,6 +47,14 @@
            "Filters the given target IDs by returning a list of any that have metadata with the given
             `attrs` and `values`."
            (ok (avus/filter-targets-by-avus target-types target-ids avus)))
+
+    (POST "/search" []
+          :query [params StandardUserQueryParams]
+          :body [body AvuSearchParams]
+          :return schema/AvuList
+          :summary "List AVUs."
+          :description "Lists AVUs matching parameters in the request body."
+          (ok (avus/list-avus body)))
 
     (GET "/:target-type/:target-id" []
           :path-params [target-id :- schema/TargetIdParam

--- a/src/metadata/routes/schemas/common.clj
+++ b/src/metadata/routes/schemas/common.clj
@@ -19,6 +19,7 @@
   (assoc StandardUserQueryParams
          (s/optional-key :attribute)   (describe [String] "Attribute names to search for.")
          (s/optional-key :target-type) (describe [TargetTypeEnum] "Target types to search for.")
+         (s/optional-key :target-id)   (describe [UUID] "Target IDs to search for.")
          (s/optional-key :value)       (describe [String] "Values to search for.")
          (s/optional-key :unit)        (describe [String] "Units to search for.")))
 

--- a/src/metadata/routes/schemas/common.clj
+++ b/src/metadata/routes/schemas/common.clj
@@ -14,10 +14,13 @@
   (assoc StandardUserQueryParams
          :data-type DataTypeParam))
 
+(s/defschema AvuSearchParams
+  (merge schema/AvuSearchParams
+         {(s/optional-key :target-type) (describe [TargetTypeEnum] "Target types to search for.")}))
+
 (s/defschema AvuSearchQueryParams
   (merge StandardUserQueryParams
-         schema/AvuSearchQueryParams
-         {(s/optional-key :target-type) (describe [TargetTypeEnum] "Target types to search for.")}))
+         AvuSearchParams))
 
 (s/defschema TargetIDList
   {:target-ids (describe [UUID] "A list of target IDs")})

--- a/src/metadata/routes/schemas/common.clj
+++ b/src/metadata/routes/schemas/common.clj
@@ -1,27 +1,23 @@
 (ns metadata.routes.schemas.common
-  (:use [common-swagger-api.schema :only [describe StandardUserQueryParams]]
-        [common-swagger-api.schema.metadata])
-  (:require [common-swagger-api.schema.metadata :as schema]
+  (:require [common-swagger-api.schema :refer [describe StandardUserQueryParams]]
+            [common-swagger-api.schema.metadata :as schema]
             [schema.core :as s])
   (:import [java.util UUID]))
 
-(def TargetTypes (concat DataTypes ["analysis" "app" "user" "quick_launch" "instant_launch"]))
+(def TargetTypes (concat schema/DataTypes ["analysis" "app" "user" "quick_launch" "instant_launch"]))
 
 (def TargetTypeEnum (apply s/enum TargetTypes))
 
-(def DataTypeParam (describe DataTypeEnum "The type of the requested data item."))
+(def DataTypeParam (describe schema/DataTypeEnum "The type of the requested data item."))
 
 (s/defschema StandardDataItemQueryParams
   (assoc StandardUserQueryParams
          :data-type DataTypeParam))
 
 (s/defschema AvuSearchQueryParams
-  (assoc StandardUserQueryParams
-         (s/optional-key :attribute)   (describe [String] "Attribute names to search for.")
-         (s/optional-key :target-type) (describe [TargetTypeEnum] "Target types to search for.")
-         (s/optional-key :target-id)   (describe [UUID] "Target IDs to search for.")
-         (s/optional-key :value)       (describe [String] "Values to search for.")
-         (s/optional-key :unit)        (describe [String] "Units to search for.")))
+  (merge StandardUserQueryParams
+         schema/AvuSearchQueryParams
+         {(s/optional-key :target-type) (describe [TargetTypeEnum] "Target types to search for.")}))
 
 (s/defschema TargetIDList
   {:target-ids (describe [UUID] "A list of target IDs")})

--- a/src/metadata/services/avus.clj
+++ b/src/metadata/services/avus.clj
@@ -1,8 +1,6 @@
 (ns metadata.services.avus
-  (:use [kameleon.uuids :only [uuid]]
-        [korma.db :only [transaction]]
-        [slingshot.slingshot :only [throw+]])
-  (:require [metadata.amqp :as amqp]
+  (:require [korma.db :refer [transaction]]
+            [metadata.amqp :as amqp]
             [metadata.persistence.avu :as persistence]))
 
 (defn- filter-targets-by-attr-values

--- a/src/metadata/services/avus.clj
+++ b/src/metadata/services/avus.clj
@@ -28,8 +28,8 @@
 (defn list-avus
   ([target-type target-id]
    {:avus (persistence/avu-list target-type target-id)})
-  ([{attributes :attribute target-types :target-type values :value units :unit}]
-   {:avus (persistence/avu-list attributes target-types values units)}))
+  ([{attributes :attribute target-types :target-type target-ids :target-id values :value units :unit}]
+   {:avus (persistence/avu-list attributes target-types target-ids values units)}))
 
 (defn- add-or-update-avu
   "Adds or Updates an AVU and its attached AVUs for the given user ID."


### PR DESCRIPTION
This PR will update the `/avus` endpoint to allow results to also be restricted to a set of `target-ids`.

It also migrates the `AvuSearchQueryParams` schema to cyverse-de/common-swagger-api#90.